### PR TITLE
bugfix: arp restrictions should apply to all, not just eth0

### DIFF
--- a/default/serverspec/sysctl_spec.rb
+++ b/default/serverspec/sysctl_spec.rb
@@ -42,11 +42,11 @@ describe 'IP V4 networking' do
        its(:value) { should eq 0 }
     end
 
-    context linux_kernel_parameter('net.ipv4.conf.eth0.arp_ignore') do
+    context linux_kernel_parameter('net.ipv4.conf.all.arp_ignore') do
        its(:value) { should eq 1 }
     end
 
-    context linux_kernel_parameter('net.ipv4.conf.eth0.arp_announce') do
+    context linux_kernel_parameter('net.ipv4.conf.all.arp_announce') do
        its(:value) { should eq 2 }
     end
 


### PR DESCRIPTION
Signed-off-by: Dominik Richter dominik.richter@gmail.com
