### PR TITLE
Remove duplicated expectation from sysctl-16

### DIFF
--- a/controls/sysctl_spec.rb
+++ b/controls/sysctl_spec.rb
@@ -175,7 +175,7 @@ control 'sysctl-16' do
   impact 1.0
   title 'Disable sending of redirects packets'
   desc 'Disable sending of redirects packets'
-  describe kernel_parameter('net.ipv4.conf.all.send_redirects') do
+  describe kernel_parameter('net.ipv4.conf.default.send_redirects') do
     its(:value) { should eq 0 }
   end
   describe kernel_parameter('net.ipv4.conf.all.send_redirects') do


### PR DESCRIPTION
Check `net.ipv4.conf.default.send_redirects` instead of `net.ipv4.conf.all.send_redirects` twice.

I believe the original intention here was to check for `default` and `all` like in preceding specs. For some reason the same expectation was repeated twice.