### PR TITLE
Ignore inspec.lock file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@
 **/Puppetfile.lock
 Gemfile.lock
 Berksfile.lock
+inspec.lock


### PR DESCRIPTION
This is a minor fix, but InSpec creates an `inspec.lock` file in the profile directory when the profile is executed and it subsequently shows up in untraced files.