### PR TITLE
Fix: more generic auditd settings

### DIFF
--- a/controls/package_spec.rb
+++ b/controls/package_spec.rb
@@ -87,10 +87,8 @@ control 'package-08' do
   describe auditd_conf do
     its('log_file') { should cmp '/var/log/audit/audit.log' }
     its('log_format') { should cmp 'raw' }
-    its('flush') { should cmp 'INCREMENTAL' }
-    its('freq') { should cmp 20 }
+    its('flush') { should match(/^INCREMENTAL|INCREMENTAL_ASYNC$/) }
     its('num_logs') { should cmp 5 }
-    its('max_log_file') { should cmp 6 }
     its('max_log_file_action') { should cmp 'ROTATE' }
     its('space_left') { should cmp 75 }
     its('action_mail_acct') { should cmp 'root' }


### PR DESCRIPTION
in order to match the defaults of all mainstream distros

Some of settings are removed, as the defaults of distros are different,
based on the intention of author [1] they are also not really important here

[1]: https://github.com/dev-sec/linux-baseline/pull/44#commitcomment-21381289

This should fix the most CI integration-testing jobs of chef-os-hardening