### PR TITLE
num_logs has different values on different distros

### DIFF
--- a/controls/package_spec.rb
+++ b/controls/package_spec.rb
@@ -88,7 +88,6 @@ control 'package-08' do
     its('log_file') { should cmp '/var/log/audit/audit.log' }
     its('log_format') { should cmp 'raw' }
     its('flush') { should match(/^INCREMENTAL|INCREMENTAL_ASYNC$/) }
-    its('num_logs') { should cmp 5 }
     its('max_log_file_action') { should cmp 'ROTATE' }
     its('space_left') { should cmp 75 }
     its('action_mail_acct') { should cmp 'root' }


### PR DESCRIPTION
on debian 7 its 4, on everything else its 5

Lets remove this as it looks related only to logrotation