### PR TITLE
Use assignment_regex, only_if and bump profile version

### DIFF
--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -171,17 +171,16 @@ control 'os-05b' do
   impact 1.0
   title 'Check login.defs - RedHat specific'
   desc 'Check owner and permissions for login.defs. Also check the configured PATH variable and umask in login.defs'
-  if os.redhat?
-    describe file('/etc/login.defs') do
-      it { should_not be_writable }
-    end
-    describe login_defs do
-      its('SYS_UID_MIN') { should eq '100' }
-      its('SYS_UID_MAX') { should eq '999' }
-      its('SYS_GID_MIN') { should eq '100' }
-      its('SYS_GID_MAX') { should eq '999' }
-    end
+  describe file('/etc/login.defs') do
+    it { should_not be_writable }
   end
+  describe login_defs do
+    its('SYS_UID_MIN') { should eq '100' }
+    its('SYS_UID_MAX') { should eq '999' }
+    its('SYS_GID_MIN') { should eq '100' }
+    its('SYS_GID_MAX') { should eq '999' }
+  end
+  only_if { os.redhat? }
 end
 
 control 'os-06' do

--- a/controls/sysctl_spec.rb
+++ b/controls/sysctl_spec.rb
@@ -354,7 +354,7 @@ control 'sysctl-33' do
   desc 'Kernel features and CPU flags provide a protection against buffer overflows. The CPU NX Flag and the kernel parameter exec-shield prevents code execution on a per memory page basis. If the CPU supports the NX-Flag then this should be used instead of the kernel parameter exec-shield.'
 
   # parse for cpu flags
-  flags = parse_config_file('/proc/cpuinfo', assignment_re: /^([^:]*?)\s+:\s+(.*?)$/).flags
+  flags = parse_config_file('/proc/cpuinfo', assignment_regex: /^([^:]*?)\s+:\s+(.*?)$/).flags
   flags ||= ''
   flags = flags.split(' ')
 

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,6 +5,6 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache 2 license
 summary: Test-suite for best-preactice Linux OS hardening
-version: 2.1.0
+version: 2.1.1
 supports:
   - os-family: linux


### PR DESCRIPTION
To avoid inspec exec warnings like these:
```
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
192.168.56.40 [DEPRECATION] `:assignment_re` is deprecated in favor of `:assignment_regex` and will be removed in the next major version. See: https://github.com/chef/inspec/issues/1709
```

and check warning:
```
$ inspec check .
Location:    .
Profile:     linux-baseline
Controls:    51
Timestamp:   2017-05-30T13:07:59+01:00
Valid:       true

  !  ./controls/os_spec.rb:170: Control os-05b has no tests defined

Summary:     0 errors, 1 warnings
```