### PR TITLE
CI: update to ruby 2.4.1 and rubocop 0.49.1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: ruby
 cache: bundler
 
 rvm:
-  - 2.3.3
+  - 2.4.1
 
 bundler_args: --without integration
 script: bundle exec rake

--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gem 'highline', '~> 1.6.0'
 gem 'inspec', '~> 1'
 gem 'rack', '1.6.4'
 gem 'rake'
-gem 'rubocop', '~> 0.46.0'
+gem 'rubocop', '~> 0.49.0'
 
 group :tools do
   gem 'github_changelog_generator', '~> 1.12.0'

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-#!/usr/bin/env rake
-
 require 'rake/testtask'
 require 'rubocop/rake_task'
 


### PR DESCRIPTION
Chef 13 is also using ruby 2.4.1 in the omnibus packages

Signed-off-by: Artem Sidorenko <artem@posteo.de>