### PR TITLE
Check for Amazon Linux when determining audit package.

### DIFF
--- a/controls/package_spec.rb
+++ b/controls/package_spec.rb
@@ -80,10 +80,7 @@ control 'package-08' do
   impact 1.0
   title 'Install auditd'
   desc 'auditd provides extended logging capacities on recent distribution'
-  audit_pkg = os.redhat? || os.suse? ? 'audit' : 'auditd'
-  puts audit_pkg
-  puts os.name
-  puts os.family
+  audit_pkg = os.redhat? || os.suse? || os.family == 'amazon' ? 'audit' : 'auditd'
   describe package(audit_pkg) do
     it { should be_installed }
   end

--- a/controls/package_spec.rb
+++ b/controls/package_spec.rb
@@ -81,6 +81,8 @@ control 'package-08' do
   title 'Install auditd'
   desc 'auditd provides extended logging capacities on recent distribution'
   audit_pkg = os.redhat? || os.suse? ? 'audit' : 'auditd'
+  puts audit_pkg
+  puts os
   describe package(audit_pkg) do
     it { should be_installed }
   end

--- a/controls/package_spec.rb
+++ b/controls/package_spec.rb
@@ -80,7 +80,7 @@ control 'package-08' do
   impact 1.0
   title 'Install auditd'
   desc 'auditd provides extended logging capacities on recent distribution'
-  audit_pkg = os.redhat? || os.suse? || os.family == 'amazon' ? 'audit' : 'auditd'
+  audit_pkg = os.redhat? || os.suse? || os.name == 'amazon' ? 'audit' : 'auditd'
   describe package(audit_pkg) do
     it { should be_installed }
   end

--- a/controls/package_spec.rb
+++ b/controls/package_spec.rb
@@ -82,7 +82,8 @@ control 'package-08' do
   desc 'auditd provides extended logging capacities on recent distribution'
   audit_pkg = os.redhat? || os.suse? ? 'audit' : 'auditd'
   puts audit_pkg
-  puts os
+  puts os.name
+  puts os.family
   describe package(audit_pkg) do
     it { should be_installed }
   end


### PR DESCRIPTION
We've been running against Amazon Linux, and while all the audit config is detected fine, the package controls are looking for the auditd package and failing.