### PR TITLE
Fix log_dir_group for Ubuntu 14.04+

### DIFF
--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -17,12 +17,8 @@
 # author: Dominik Richter
 # author: Patrick Muench
 
-log_dir_group = case os[:family]
-                when 'debian', 'redhat', 'fedora'
-                  'root'
-                when 'ubuntu'
-                  os[:release] == '14.04' ? 'syslog' : 'root'
-                end
+log_dir_group = 'root'
+log_dir_group = 'syslog' if os.name == 'ubuntu' && os[:release].to_i >= 14
 login_defs_umask = attribute('login_defs_umask', default: os.redhat? ? '077' : '027', description: 'Default umask to set in login.defs')
 login_defs_passmaxdays = attribute('login_defs_passmaxdays', default: '60', description: 'Default password maxdays to set in login.defs')
 login_defs_passmindays = attribute('login_defs_passmindays', default: '7', description: 'Default password mindays to set in login.defs')


### PR DESCRIPTION
Currently the `case` statement won't work as `os[:family]` on Ubuntu systems is `debian`, this fixes that.
