### PR TITLE
Update Fedora controls

### DIFF
--- a/controls/package_spec.rb
+++ b/controls/package_spec.rb
@@ -74,13 +74,17 @@ control 'package-07' do
   describe package(val_syslog_pkg) do
     it { should be_installed }
   end
+  # Fedora doesn't install with a syslogger out of the box and instead uses
+  # systemd journal; as there is there is no affinity towards either rsyslog
+  # or syslog-ng, we'll skip this check on Fedora hosts.
+  only_if { os.name != 'fedora' }
 end
 
 control 'package-08' do
   impact 1.0
   title 'Install auditd'
   desc 'auditd provides extended logging capacities on recent distribution'
-  audit_pkg = os.redhat? || os.suse? || os.name == 'amazon' ? 'audit' : 'auditd'
+  audit_pkg = os.redhat? || os.suse? || os.name == 'amazon' || os.name == 'fedora' ? 'audit' : 'auditd'
   describe package(audit_pkg) do
     it { should be_installed }
   end


### PR DESCRIPTION
* The audit package on Fedora is called `audit` and not `auditd`, so updated condition.

* Fedora doesn't install with a syslog package so for now skipping it, maybe more of a discussion point as then a default should be decided - either rsyslog or syslog-ng - for remediation via puppet/chef/ansible .