### PR TITLE
CIS 4.1.1.3

### DIFF
--- a/controls/package_spec.rb
+++ b/controls/package_spec.rb
@@ -88,7 +88,7 @@ control 'package-08' do
     its('log_file') { should cmp '/var/log/audit/audit.log' }
     its('log_format') { should cmp 'raw' }
     its('flush') { should match(/^INCREMENTAL|INCREMENTAL_ASYNC$/) }
-    its('max_log_file_action') { should cmp 'ROTATE' }
+    its('max_log_file_action') { should cmp 'keep_logs' }
     its('space_left') { should cmp 75 }
     its('action_mail_acct') { should cmp 'root' }
     its('space_left_action') { should cmp 'SYSLOG' }


### PR DESCRIPTION
For CIS v2.1:

4.1.1.3 Ensure audit logs are not automatically deleted:

Audit:
Run the following command and verify output matches:
```max_log_file_action = keep_logs```
