### PR TITLE
deferring the execution of permissions to profile execution

### DIFF
--- a/libraries/suid_blacklist.rb
+++ b/libraries/suid_blacklist.rb
@@ -1,0 +1,53 @@
+# encoding: utf-8
+
+# author: Christoph Hartmann
+
+class SUIDBlacklist < Inspec.resource(1)
+  name 'suid_blacklist'
+  desc 'The suid_blacklist resoruce returns the default suid blacklist'
+
+  def default
+    [
+      # blacklist as provided by NSA
+      '/usr/bin/rcp', '/usr/bin/rlogin', '/usr/bin/rsh',
+      # sshd must not use host-based authentication (see ssh cookbook)
+      '/usr/libexec/openssh/ssh-keysign',
+      '/usr/lib/openssh/ssh-keysign',
+      # misc others
+      '/sbin/netreport',                                            # not normally required for user
+      '/usr/sbin/usernetctl',                                       # modify interfaces via functional accounts
+      # connecting to ...
+      '/usr/sbin/userisdnctl',                                      # no isdn...
+      '/usr/sbin/pppd',                                             # no ppp / dsl ...
+      # lockfile
+      '/usr/bin/lockfile',
+      '/usr/bin/mail-lock',
+      '/usr/bin/mail-unlock',
+      '/usr/bin/mail-touchlock',
+      '/usr/bin/dotlockfile',
+      # need more investigation, blacklist for now
+      '/usr/bin/arping',
+      '/usr/sbin/arping',
+      '/usr/sbin/uuidd',
+      '/usr/bin/mtr',                                               # investigate current state...
+      '/usr/lib/evolution/camel-lock-helper-1.2',                   # investigate current state...
+      '/usr/lib/pt_chown',                                          # pseudo-tty, needed?
+      '/usr/lib/eject/dmcrypt-get-device',
+      '/usr/lib/mc/cons.saver' # midnight commander screensaver
+      # from Ubuntu xenial, need to investigate
+      # '/sbin/unix_chkpwd',
+      # '/sbin/pam_extrausers_chkpwd',
+      # '/usr/lib/x86_64-linux-gnu/utempter/utempter',
+      # '/usr/sbin/postdrop',
+      # '/usr/sbin/postqueue',
+      # '/usr/bin/ssh-agent',
+      # '/usr/bin/mlocate',
+      # '/usr/bin/crontab',
+      # '/usr/bin/screen',
+      # '/usr/bin/expiry',
+      # '/usr/bin/wall',
+      # '/usr/bin/chage',
+      # '/usr/bin/bsd-write'
+    ]
+  end
+end

--- a/libraries/suid_check.rb
+++ b/libraries/suid_check.rb
@@ -1,0 +1,27 @@
+# encoding: utf-8
+
+# author: Christoph Hartmann
+
+class SUIDCheck < Inspec.resource(1)
+  name 'suid_check'
+  desc 'Use the suid_check resource to verify the current SUID/SGID against a blacklist'
+  example "
+     describe suid_check(blacklist) do
+       its('diff') { should be_empty }
+     end
+   "
+
+  def initialize(blacklist = nil)
+    blacklist = default if blacklist.nil?
+    @blacklist = blacklist
+  end
+
+  def permissions
+    output = inspec.command('find / -perm -4000 -o -perm -2000 -type f ! -path \'/proc/*\' ! -path \'/var/lib/lxd/containers/*\' -print 2>/dev/null | grep -v \'^find:\'')
+    output.stdout.split(/\r?\n/)
+  end
+
+  def diff
+    permissions & @blacklist
+  end
+end


### PR DESCRIPTION
by using resources, we can defer the execution to runtime, which allows to use inspec's skip mechanisms

fixes #86