### PR TITLE
Fixes #89 false positive /etc/shadow on Fedora

### DIFF
--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -55,7 +55,7 @@ control 'os-02' do
     it { should_not be_executable }
     it { should_not be_readable.by('other') }
   end
-  if os.redhat?
+  if os.redhat? || os.name == 'fedora'
     describe file('/etc/shadow') do
       it { should_not be_writable.by('owner') }
       it { should_not be_readable.by('owner') }


### PR DESCRIPTION
On Fedora you get a false positive in `os-02` as `/etc/shadow` has 000 permissions like RedHat. This is fixed with this PR.

Signed-off-by: Marcel <marcel.huth111@gmail.com>