### PR TITLE
add attributes to exclude fstypes and paths from suid_check find

### DIFF
--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -37,6 +37,18 @@ blacklist = attribute(
   description: 'blacklist of suid/sgid program on system'
 )
 
+find_exclude_paths = attribute(
+  'find_exclude_paths',
+  default: suid_check.default_exclude_paths,
+  description: 'exclude paths from being walked by find for permissions issues'
+)
+
+find_exclude_fstypes = attribute(
+  'find_exclude_fstypes',
+  default: suid_check.default_exclude_fstypes,
+  description: 'exclude mounts with these fstypes from being walked by find for permissions issues'
+)
+
 control 'os-01' do
   impact 1.0
   title 'Trusted hosts login'
@@ -158,7 +170,7 @@ control 'os-06' do
   title 'Check for SUID/ SGID blacklist'
   desc 'Find blacklisted SUID and SGID files to ensure that no rogue SUID and SGID files have been introduced into the system'
 
-  describe suid_check(blacklist) do
+  describe suid_check(blacklist, exclude_fstypes: find_exclude_fstypes, exclude_paths: find_exclude_paths) do
     its('diff') { should be_empty }
   end
 end

--- a/libraries/suid_check.rb
+++ b/libraries/suid_check.rb
@@ -4,19 +4,42 @@ class SUIDCheck < Inspec.resource(1)
   name 'suid_check'
   desc 'Use the suid_check resource to verify the current SUID/SGID against a blacklist'
   example "
-     describe suid_check(blacklist) do
+     describe suid_check(blacklist, exclude_fstypes: %w[nfs nfs4], exclude_paths: %w[/proc]) do
        its('diff') { should be_empty }
      end
    "
 
-  def initialize(blacklist = nil)
-    blacklist = default if blacklist.nil?
+  def initialize(blacklist = nil, exclude_fstypes: nil, exclude_paths: nil)
     @blacklist = blacklist
+    @exclude_fstypes = exclude_fstypes || default_exclude_fstypes
+    @exclude_paths = exclude_paths || default_exclude_paths
+  end
+
+  def default_exclude_fstypes
+    %w[nfs nfs4 cifs smp nbd ceph]
+  end
+
+  def default_exclude_paths
+    %w[/sys /proc /var/lib/lxd/containers]
   end
 
   def permissions
-    output = inspec.command('find / -perm -4000 -o -perm -2000 -type f ! -path \'/proc/*\' ! -path \'/var/lib/lxd/containers/*\' -print 2>/dev/null | grep -v \'^find:\'')
+    exclude_opts = exclude_paths.map { |p| "-path #{p} -prune" }.join(' -o ')
+    output = inspec.command("find / \\( #{exclude_opts} \\) -o -perm -4000 -perm -2000 -type f -print 2>/dev/null " \
+                            "| grep -v '^find:'")
     output.stdout.split(/\r?\n/)
+  end
+
+  def exclude_fstype_paths
+    mounts = inspec.command('mount')
+    mounts.stdout.split("\n").map do |m|
+      match = m.match(/ on (?<mount_path>.*) type (?<fstype>\w+) /)
+      match['mount_path'] if !match.nil? && @exclude_fstypes.include?(match['fstype'])
+    end.compact
+  end
+
+  def exclude_paths
+    exclude_fstype_paths + @exclude_paths
   end
 
   def diff


### PR DESCRIPTION
This profile has been blocking systems with network mounts for extended periods because find walks all of /. This pull by default will ignore network filesystems in the find as well as /sys, /proc and /var/lib/lxd/containers. They are also able to be overriden with the `find_exclude_paths` and `find_exclude_fstypes` attributes. This should speed up the profile execute greatly on systems with large network mounts.

Fixes #53 #78 