### PR TITLE
fix virtualization usage in older inspec versions

### DIFF
--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -27,7 +27,11 @@ login_defs_passwarnage = attribute('login_defs_passwarnage', default: '7', descr
 
 shadow_group = 'root'
 shadow_group = 'shadow' if os.debian? || os.suse?
-container_execution = virtualization.role == 'guest' && virtualization.system =~ /^(lxc|docker)$/
+container_execution = begin
+                        virtualization.role == 'guest' && virtualization.system =~ /^(lxc|docker)$/
+                      rescue NoMethodError
+                        false
+                      end
 
 blacklist = attribute(
   'blacklist',

--- a/controls/package_spec.rb
+++ b/controls/package_spec.rb
@@ -18,7 +18,11 @@
 # author: Patrick Muench
 
 val_syslog_pkg = attribute('syslog_pkg', default: 'rsyslog', description: 'syslog package to ensure present (default: rsyslog, alternative: syslog-ng...')
-container_execution = virtualization.role == 'guest' && virtualization.system =~ /^(lxc|docker)$/
+container_execution = begin
+                        virtualization.role == 'guest' && virtualization.system =~ /^(lxc|docker)$/
+                      rescue NoMethodError
+                        false
+                      end
 
 control 'package-01' do
   impact 1.0

--- a/controls/sysctl_spec.rb
+++ b/controls/sysctl_spec.rb
@@ -19,7 +19,11 @@
 
 sysctl_forwarding = attribute('sysctl_forwarding', default: false, description: 'Is network forwarding needed?')
 kernel_modules_disabled = attribute('kernel_modules_disabled', default: 0, description: 'Should loading of kernel modules be disabled?')
-container_execution = virtualization.role == 'guest' && virtualization.system =~ /^(lxc|docker)$/
+container_execution = begin
+                        virtualization.role == 'guest' && virtualization.system =~ /^(lxc|docker)$/
+                      rescue NoMethodError
+                        false
+                      end
 
 control 'sysctl-01' do
   impact 1.0


### PR DESCRIPTION
This profile throws an exception when using InSpec < 2.0.30 on non-virtualized systems because this fix (https://github.com/inspec/inspec/pull/2603) was not included in prior versions. This pull simply catches the exception where virtualization.* is called in pure Ruby.

Older versions are still very much alive in bundles of Chef Automate 1.x and ChefDK 2.x and are difficult to upgrade ad-hoc.