### PR TITLE
ubuntu 16.04 and onward use root group for /var/log

### DIFF
--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -18,7 +18,7 @@
 # author: Patrick Muench
 
 log_dir_group = 'root'
-log_dir_group = 'syslog' if os.name == 'ubuntu' && os[:release].to_i >= 14
+log_dir_group = 'syslog' if os.name == 'ubuntu' && os[:release].to_i == 14
 login_defs_umask = attribute('login_defs_umask', default: os.redhat? ? '077' : '027', description: 'Default umask to set in login.defs')
 
 login_defs_passmaxdays = attribute('login_defs_passmaxdays', default: '60', description: 'Default password maxdays to set in login.defs')


### PR DESCRIPTION
This can be tested by the following:
- `docker run --rm -ti ubuntu:16.04 ls -al /var/log`
- `docker run --rm -ti ubuntu:18.04 ls -al /var/log`

Both use *root* as group.