### PR TITLE
Updated package_spec controls naming convention

### DIFF
--- a/controls/package_spec.rb
+++ b/controls/package_spec.rb
@@ -54,7 +54,7 @@ control 'package-03' do
   end
 end
 
-control 'package-05' do
+control 'package-04' do
   impact 1.0
   title 'Do not install ypserv server (NIS)'
   desc 'Network Information Service (NIS) has some security design weaknesses like inadequate protection of important authentication information. http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf, Chapter 3.2.4'
@@ -63,7 +63,7 @@ control 'package-05' do
   end
 end
 
-control 'package-06' do
+control 'package-05' do
   impact 1.0
   title 'Do not install tftp server'
   desc 'tftp-server provides little security http://www.nsa.gov/ia/_files/os/redhat/rhel5-guide-i731.pdf, Chapter 3.2.5'
@@ -72,7 +72,7 @@ control 'package-06' do
   end
 end
 
-control 'package-07' do
+control 'package-06' do
   impact 1.0
   title 'Install syslog server package'
   desc 'Syslog server is required to receive system and applications logs'
@@ -85,7 +85,7 @@ control 'package-07' do
   end
 end
 
-control 'package-08' do
+control 'package-07' do
   impact 1.0
   title 'Install auditd'
   desc 'auditd provides extended logging capabilities on recent distributions'
@@ -109,7 +109,7 @@ control 'package-08' do
   end
 end
 
-control 'package-09' do
+control 'package-08' do
   impact 1.0
   title 'CIS: Additional process hardening'
   desc '1.5.4 Ensure prelink is disabled'


### PR DESCRIPTION
`package-04` was incorrectly named `package-05` which incorrectly labelled the following controls.