### PR TITLE
Bump version to 2.3.0 and switch to inspec 3 for check

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -2,9 +2,6 @@
 AllCops:
   Exclude:
   - vendor/**/*
-  - "*/puppet/Puppetfile"
-  - "*/puppet/.tmp/**/*"
-  TargetRubyVersion: 1.9
 Documentation:
   Enabled: false
 AlignParameters:
@@ -14,6 +11,8 @@ HashSyntax:
 LineLength:
   Enabled: false
 EmptyLinesAroundBlockBody:
+  Enabled: false
+Style/IfUnlessModifier:
   Enabled: false
 MethodLength:
   Max: 40

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,33 @@
 # Change Log
 
+## [2.3.0](https://github.com/dev-sec/linux-baseline/tree/2.3.0) (2019-05-14)
+[Full Changelog](https://github.com/dev-sec/linux-baseline/compare/2.2.2...2.3.0)
+
+**Closed issues:**
+
+- Audit Daemon Fails on Amazon Linux 2 [\#109](https://github.com/dev-sec/linux-baseline/issues/109)
+- os-11 fails on vanilla Ubuntu 16.04/18.04 [\#104](https://github.com/dev-sec/linux-baseline/issues/104)
+- Container conditions to skip tests? [\#102](https://github.com/dev-sec/linux-baseline/issues/102)
+- Duplicate testing for telnetd instead of rsh [\#97](https://github.com/dev-sec/linux-baseline/issues/97)
+- Profile summary VS Test Summary  [\#93](https://github.com/dev-sec/linux-baseline/issues/93)
+- Control Sysctl 31-b from sysctl\_spec.rb causing Inspec to exit with error code [\#92](https://github.com/dev-sec/linux-baseline/issues/92)
+
+**Merged pull requests:**
+
+- Add compatibility for alpine based images [\#111](https://github.com/dev-sec/linux-baseline/pull/111) ([zopanix](https://github.com/zopanix))
+- Minor grammatical fix in README [\#108](https://github.com/dev-sec/linux-baseline/pull/108) ([cachedout](https://github.com/cachedout))
+- Update issue templates [\#106](https://github.com/dev-sec/linux-baseline/pull/106) ([rndmh3ro](https://github.com/rndmh3ro))
+- \#104 Fix os-11 for Ubuntu 16.04 and newer [\#105](https://github.com/dev-sec/linux-baseline/pull/105) ([IceBear2k](https://github.com/IceBear2k))
+- efi-check should run on remote host, not locally [\#103](https://github.com/dev-sec/linux-baseline/pull/103) ([rndmh3ro](https://github.com/rndmh3ro))
+- update grammar in desc [\#101](https://github.com/dev-sec/linux-baseline/pull/101) ([juliandunn](https://github.com/juliandunn))
+- Update to test for rsh-server instead of duplicate telnetd [\#98](https://github.com/dev-sec/linux-baseline/pull/98) ([aavetis](https://github.com/aavetis))
+
 ## [2.2.2](https://github.com/dev-sec/linux-baseline/tree/2.2.2) (2018-07-19)
 [Full Changelog](https://github.com/dev-sec/linux-baseline/compare/2.2.1...2.2.2)
 
 **Merged pull requests:**
 
+- Update to version 2.2.2 [\#99](https://github.com/dev-sec/linux-baseline/pull/99) ([james-stocks](https://github.com/james-stocks))
 - Do not disable vfat by default [\#96](https://github.com/dev-sec/linux-baseline/pull/96) ([rndmh3ro](https://github.com/rndmh3ro))
 - fix virtualization usage in older inspec versions [\#95](https://github.com/dev-sec/linux-baseline/pull/95) ([mattlqx](https://github.com/mattlqx))
 

--- a/Gemfile
+++ b/Gemfile
@@ -1,11 +1,14 @@
+# frozen_string_literal: true
+
 source 'https://rubygems.org'
 
-gem 'highline', '~> 1.6.0'
-gem 'inspec', '>= 2.0.30'
-gem 'rack', '1.6.4'
-gem 'rake'
-gem 'rubocop', '~> 0.49.0'
+gem 'highline', '~> 2.0.2'
+gem 'inspec', '~> 3'
+gem 'rack', '~> 2.0.7'
+gem 'rake', '~> 12.3.2'
+gem 'rubocop', '~> 0.68.1'
 
 group :tools do
-  gem 'github_changelog_generator', '~> 1.12.0'
+  gem 'github_changelog_generator', '~> 1.14.3'
+  gem 'pry-coolline', '~> 0.2.5'
 end

--- a/Rakefile
+++ b/Rakefile
@@ -17,23 +17,30 @@ task default: [:lint, 'test:check']
 namespace :test do
   # run inspec check to verify that the profile is properly configured
   task :check do
-    dir = File.join(File.dirname(__FILE__))
-    sh("bundle exec inspec check #{dir}")
+    require 'inspec'
+    puts "Checking profile with InSpec Version: #{Inspec::VERSION}"
+    profile = Inspec::Profile.for_target('.', backend: Inspec::Backend.create(Inspec::Config.mock))
+    pp profile.check
   end
 end
 
-# Automatically generate a changelog for this project. Only loaded if
-# the necessary gem is installed. By default its picking up the version from
-# inspec.yml. You can override that behavior with s`rake changelog to=1.2.0`
-begin
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts "Generate changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
+task :changelog do
+  # Automatically generate a changelog for this project. Only loaded if
+  # the necessary gem is installed. By default its picking up the version from
+  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
+  begin
+    require 'yaml'
+    metadata = YAML.load_file('inspec.yml')
+    v = ENV['to'] || metadata['version']
+    puts " * Generating changelog for version #{v}"
+    require 'github_changelog_generator/task'
+    GitHubChangelogGenerator::RakeTask.new :changelog do |config|
+      config.future_release = v
+      config.user = 'dev-sec'
+      config.project = 'linux-baseline'
+    end
+    Rake::Task[:changelog].execute
+  rescue LoadError
+    puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
   end
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
 end

--- a/inspec.yml
+++ b/inspec.yml
@@ -5,6 +5,6 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Test suite for best practice Linux OS hardening
-version: 2.2.2
+version: 2.3.0
 supports:
   - os-family: linux

--- a/libraries/suid_blacklist.rb
+++ b/libraries/suid_blacklist.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # author: Christoph Hartmann
 
 class SUIDBlacklist < Inspec.resource(1)

--- a/libraries/suid_check.rb
+++ b/libraries/suid_check.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 # author: Christoph Hartmann
 
 class SUIDCheck < Inspec.resource(1)


### PR DESCRIPTION
Switched to inspec check without CLI, this will allow checking the profile with inspec 4 without having to auto accept the license.

I updated the Rakefile to only load the changelog task when it is targetted.

I had to specify the repo user and project in the config of the changelog task, otherwise, I was getting this exception:

```
Octokit::InvalidRepository: "/" is invalid as a repository identifier. Use the user/repo (String) format
```