### PR TITLE
Allow core dumps to be piped into a program with an absolute path.

### DIFF
--- a/controls/sysctl_spec.rb
+++ b/controls/sysctl_spec.rb
@@ -371,7 +371,7 @@ control 'sysctl-31b' do
   desc 'Ensure that core dumps are done with fully qualified path'
   only_if { kernel_parameter('fs.suid_dumpable').value == 2 && !container_execution }
   describe kernel_parameter('kernel.core_pattern') do
-    its(:value) { should match %r{^/.*} }
+    its(:value) { should match %r{^\|?/.*} }
   end
 end
 


### PR DESCRIPTION
Since Linux 3.6, if /proc/sys/fs/suid_dumpable is set to 2 ("suidsafe"), the pattern must be either an  absolute path or a pipe.

Ensures the pipe pattern meets the requirements of kernel 2.6.19 (pipe immediately followed by an absolute path).