### PR TITLE
Adds /etc/passwd format check

### DIFF
--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -104,7 +104,7 @@ control 'os-03b' do
   title 'Check passwords hashes in /etc/passwd'
   desc 'Check periodically that /etc/passwd does not contain passwords'
   describe passwd do
-    its('passwords') { should be_in ['x'] }
+    its('passwords') { should be_in ['x', '*', '!'] }
   end
 end
 

--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -104,7 +104,7 @@ control 'os-03b' do
   title 'Check passwords hashes in /etc/passwd'
   desc 'Check periodically that /etc/passwd does not contain passwords'
   describe passwd do
-    its('passwords') { should be_in ['x', '*', '!'] }
+    its('passwords') { should be_in ['x', '*'] }
   end
 end
 

--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -99,6 +99,15 @@ control 'os-03' do
   end
 end
 
+control 'os-03b' do
+  impact 1.0
+  title 'Check passwords hashes in /etc/passwd'
+  desc 'Check periodically that /etc/passwd does not contain passwords'
+  describe passwd do
+    its('passwords') { should be_in ['x'] }
+  end
+end
+
 control 'os-04' do
   impact 1.0
   title 'Dot in PATH variable'


### PR DESCRIPTION
Fixes #117 

When a password exists in file /etc/passwd it returns:

```rb
Profile: tests from singlessh.rb (tests from singlessh.rb)
Version: (not specified)
Target:  ssh://pi@10.100.10.5:22

  ×  os-03b: Check passwords hashes in /etc/passwd
     ×  /etc/passwd passwords is expected to be in "x"
     expected `["x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "x", "$6$Z67dT12H$GdGlCyHTkHca6sUQFhAhOLowjv0TuekQeVgoO1mHGL7.DXWFAbXpYL65jEV.", "x"]` to be in the list: `["x"]` 
     Diff:
      ["$6$Z67dT12H$GdGlCyHTkHca6sUQFhAhOLowjv0TuekQeVgoO1mHGL7.DXWFAbXpYL65jEV."]


Profile Summary: 0 successful controls, 1 control failure, 0 controls skipped
Test Summary: 0 successful, 1 failure, 0 skipped
```

When no passwords in file:

```rb
Profile: tests from singlessh.rb (tests from singlessh.rb)
Version: (not specified)
Target:  ssh://pi@10.100.10.5:22

  ✔  os-03b: Check passwords hashes in /etc/passwd
     ✔  /etc/passwd passwords is expected to be in "x"


Profile Summary: 1 successful control, 0 control failures, 0 controls skipped
Test Summary: 1 successful, 0 failures, 0 skipped
```