### PR TITLE
use input instead of attribute

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -25,24 +25,3 @@ namespace :test do
     pp profile.check
   end
 end
-
-task :changelog do
-  # Automatically generate a changelog for this project. Only loaded if
-  # the necessary gem is installed. By default its picking up the version from
-  # inspec.yml. You can override that behavior with `rake changelog to=1.2.0`
-
-  require 'yaml'
-  metadata = YAML.load_file('inspec.yml')
-  v = ENV['to'] || metadata['version']
-  puts " * Generating changelog for version #{v}"
-  require 'github_changelog_generator/task'
-  GitHubChangelogGenerator::RakeTask.new :changelog do |config|
-    config.future_release = v
-    config.user = 'dev-sec'
-    config.project = 'linux-baseline'
-  end
-  Rake::Task[:changelog].execute
-rescue LoadError
-  puts '>>>>> GitHub Changelog Generator not loaded, omitting tasks'
-
-end

--- a/controls/os_spec.rb
+++ b/controls/os_spec.rb
@@ -19,11 +19,11 @@
 # author: Dominik Richter
 # author: Patrick Muench
 
-login_defs_umask = attribute('login_defs_umask', value: os.redhat? ? '077' : '027', description: 'Default umask to set in login.defs')
+login_defs_umask = input('login_defs_umask', value: os.redhat? ? '077' : '027', description: 'Default umask to set in login.defs')
 
-login_defs_passmaxdays = attribute('login_defs_passmaxdays', value: '60', description: 'Default password maxdays to set in login.defs')
-login_defs_passmindays = attribute('login_defs_passmindays', value: '7', description: 'Default password mindays to set in login.defs')
-login_defs_passwarnage = attribute('login_defs_passwarnage', value: '7', description: 'Default password warnage (days) to set in login.defs')
+login_defs_passmaxdays = input('login_defs_passmaxdays', value: '60', description: 'Default password maxdays to set in login.defs')
+login_defs_passmindays = input('login_defs_passmindays', value: '7', description: 'Default password mindays to set in login.defs')
+login_defs_passwarnage = input('login_defs_passwarnage', value: '7', description: 'Default password warnage (days) to set in login.defs')
 
 shadow_group = 'root'
 shadow_group = 'shadow' if os.debian? || os.suse? || os.name == 'alpine'

--- a/controls/sysctl_spec.rb
+++ b/controls/sysctl_spec.rb
@@ -19,8 +19,8 @@
 # author: Dominik Richter
 # author: Patrick Muench
 
-sysctl_forwarding = attribute('sysctl_forwarding', value: false, description: 'Is network forwarding needed?')
-kernel_modules_disabled = attribute('kernel_modules_disabled', value: 0, description: 'Should loading of kernel modules be disabled?')
+sysctl_forwarding = input('sysctl_forwarding', value: false, description: 'Is network forwarding needed?')
+kernel_modules_disabled = input('kernel_modules_disabled', value: 0, description: 'Should loading of kernel modules be disabled?')
 container_execution = begin
   virtualization.role == 'guest' && virtualization.system =~ /^(lxc|docker)$/
 rescue NoMethodError

--- a/inspec.yml
+++ b/inspec.yml
@@ -6,6 +6,7 @@ copyright: DevSec Hardening Framework Team
 copyright_email: hello@dev-sec.io
 license: Apache-2.0
 summary: Test suite for best practice Linux OS hardening
+inspec_version: '>= 4.6.3'
 version: 2.8.1
 supports:
     - os-family: linux


### PR DESCRIPTION
In the last versions of Inspec and cinc-auditor, attribute is deprecated and input should be used.

https://docs.chef.io/workstation/cookstyle/inspec_deprecations_attributehelper/