### PR TITLE
Improve SUID find

### DIFF
--- a/libraries/suid_check.rb
+++ b/libraries/suid_check.rb
@@ -18,7 +18,7 @@ class SUIDCheck < Inspec.resource(1)
   end
 
   def permissions
-    output = inspec.command('find / -perm -4000 -o -perm -2000 -type f ! -path \'/proc/*\' ! -path \'/var/lib/lxd/containers/*\' -print 2>/dev/null | grep -v \'^find:\'')
+    output = inspec.command('find / -type d \( -path \'/proc/*\' -o -path \'/var/lib/lxd/containers/*\' \) -prune -type f -o -perm -2000 -o -perm 4000 2>/dev/null | grep -v \'^find:\'')
     output.stdout.split(/\r?\n/)
   end
 


### PR DESCRIPTION
I have this proposal to improve the SUID find.

To test it, I've created a structure with this script:
```
#!/bin/bash                                                                                            
                                                                                                       
for i in simple ignore1 ignore2 root; do                                                               
  mkdir -p $i                                                                                          
  for j in file1 file2 file_root file_2000 file_4000; do                                               
    touch $i/$j                                                                                        
  done                                                                                                 
done                                                                                                   
                                                                                                       
mkdir -p ignore1/root                                                                                  
mkdir -p ignore2/root                                                                                  
                                                                                                       
                                                                                                       
find . -name file_2000 -exec chmod 2000 {} \;                                                          
find . -name file_4000 -exec chmod 4000 {} \;                                                          
sudo find . -name "*root" -exec chown root:root {} \;                                                  
sudo find . -name "*root" -exec chmod o-rwx {} \;                                                      
                                                                                                       
tree -pu                                                                                               
                                                                                                       
echo "original:"                                                                                       
find . -perm -4000 -o -perm -2000 -type f ! -path './ignore1/*' ! -path './ignore2/*' -print           
                                                                                                       
echo "proposal:"                                                                                       
find . -type d \( -path "./ignore1" -o -path "./ignore2" \) -prune -type f -o -perm -2000 -o -perm 4000
```
As you can see, I modified the original `find` slightly to match my structure and to find in `.`, but it is essentially the same.

Running it looks like this:

![image](https://user-images.githubusercontent.com/584026/153719075-8c83e191-44be-4ccb-ab92-8319c09efc94.png)

There are some differences between my proposal and the original one:
- my proposal found two files meanwhile the original just one.
- my proposal successfully ignored completely the directories to be ignored, meanwhile the original entered on them and then ignored the files. So I decided to run the original one as it is, but avoiding to ignore the errors and ignoring `/snap` because it was faster:
![image](https://user-images.githubusercontent.com/584026/153719281-f1c417ea-8d08-4897-9f30-22ead732520f.png)

It seems to enter in the ignored directories and then ignore their content. My proposal just ignore them effectively, so it is much faster.

Note: I'm not sure if backslashes for parents should be duplicated when using the command in ruby.