### PR TITLE
Restrict ptrace attach to privileged users

### DIFF
--- a/controls/sysctl_spec.rb
+++ b/controls/sysctl_spec.rb
@@ -432,3 +432,13 @@ control 'sysctl-34' do
     its(:value) { should eq 1 }
   end
 end
+
+control 'sysctl-35' do
+  impact 1.0
+  title 'Restrict ptrace attach to privileged users'
+  desc 'Ensure kernel.yama.ptrace_scope is set to at least 2 so unprivileged users cannot attach ptrace to arbitrary processes.'
+  only_if { !container_execution }
+  describe kernel_parameter('kernel.yama.ptrace_scope') do
+    its(:value) { should >= 2 }
+  end
+end

--- a/controls/sysctl_spec.rb
+++ b/controls/sysctl_spec.rb
@@ -439,6 +439,6 @@ control 'sysctl-35' do
   desc 'Ensure kernel.yama.ptrace_scope is set to at least 2 so unprivileged users cannot attach ptrace to arbitrary processes.'
   only_if { !container_execution }
   describe kernel_parameter('kernel.yama.ptrace_scope') do
-    its(:value) { should >= 2 }
+    its(:value) { should eq(2).or eq(3).or eq(nil) } # include nil because SuSE does not have this parameter
   end
 end

--- a/controls/sysctl_spec.rb
+++ b/controls/sysctl_spec.rb
@@ -437,8 +437,9 @@ control 'sysctl-35' do
   impact 1.0
   title 'Restrict ptrace attach to privileged users'
   desc 'Ensure kernel.yama.ptrace_scope is set to at least 2 so unprivileged users cannot attach ptrace to arbitrary processes.'
-  only_if { !container_execution }
+  # exclude SuSE because it does not have this parameter
+  only_if { !(container_execution || os.suse?) }
   describe kernel_parameter('kernel.yama.ptrace_scope') do
-    its(:value) { should eq(2).or eq(3).or eq(nil) } # include nil because SuSE does not have this parameter
+    its(:value) { should >= 2 }
   end
 end


### PR DESCRIPTION
This pull request adds a new security control to the `sysctl_spec.rb` file to ensure that only privileged users can use ptrace to attach to processes. This helps prevent unprivileged users from interfering with or inspecting other processes, enhancing system security.

Security hardening:

* Added a control (`sysctl-35`) to verify that the `kernel.yama.ptrace_scope` parameter is set to at least 2, restricting ptrace attach operations to privileged users.